### PR TITLE
Custom security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Access Server script ./sacli
             /stg                    # Staging Environment
             /prd                    # Production Environment
 
-    
+
 ### backend.tf
 
     terraform {
@@ -107,13 +107,14 @@ Access Server script ./sacli
         openvpn_all_access              = ["<cidr_block>","<cidr_block>]
         openvpn_ssh_access              = ["<cidr_block>","<cidr_block>]
         openvpn_ldap_server_1           = "<ldap_server>"  # e.g. ldap.jumpcloud.com
-        openvpn_ldap_server_2           = "<ldap_server>"  # e.g. ldap.jumpcloud.com  
+        openvpn_ldap_server_2           = "<ldap_server>"  # e.g. ldap.jumpcloud.com
         openvpn_ldap_bind_dn            = "uid=ldapuser,ou=Users,o=<account_id>,dc=jumpcloud,dc=com"
         openvpn_ldap_bind_pswd          = "${data.aws_ssm_parameter.openvpn_ldap_bind_pswd.value}"
         openvpn_ldap_base_dn            = "ou=Users,o=<account_id>,dc=jumpcloud,dc=com"
         openvpn_ldap_uname_attr         = "uid"
         openvpn_ldap_add_req            = "memberOf=cn=openvpn,ou=Users,o=<account_id>,dc=jumpcloud,dc=com"
         openvpn_ldap_use_ssl            = "always"
+        custom_security_groups          = ["<security group ID", "security group ID"]
     }
 
 ### providers.tf

--- a/aws_instance.openvpn.tf
+++ b/aws_instance.openvpn.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "openvpn" {
 
   vpc_security_group_ids = [
     "${aws_security_group.openvpn.id}",
+    "${var.custom_security_groups}",
   ]
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable openvpn_reroute_dns {
 ### SECURITY GROUP CONFIGURATION
 ###############################################################################
 
+# List of additional security group ID's to add to EC2 instance
+variable custom_security_groups {
+  type = "list"
+  default = []
+}
+
 # WHITELIST CIDR_BLOCK(s) FOR ALL TRAFFIC (All TCP/UDP)
 # (e.g. Private CIDR_BLOCK)
 variable openvpn_all_access {
@@ -167,5 +173,5 @@ variable openvpn_ldap_add_req {
 variable openvpn_ldap_use_ssl {
   type = "string"
   default = "always"
-  
+
 }


### PR DESCRIPTION
Adds ability to include list of additional security groups, for example
allowing connection to hosts in a VPC. Defaults to empty list not to break
existing code.