### PR TITLE
Add 2FA option using Google Authenticator

### DIFF
--- a/aws_instance.openvpn.tf
+++ b/aws_instance.openvpn.tf
@@ -55,5 +55,6 @@ data "template_file" "user_data" {
     ldap_uname_attr="${var.openvpn_ldap_uname_attr}"
     ldap_add_req="${var.openvpn_ldap_add_req}"
     ldap_use_ssl="${var.openvpn_ldap_use_ssl}"
+    use_google_auth = "${var.use_google_auth}"
   }
 }

--- a/user_data.tpl
+++ b/user_data.tpl
@@ -14,6 +14,7 @@ admin_pw=${admin_pswd}
 license=${license_key}
 reroute_gw=${reroute_gw}
 reroute_dns=${reroute_dns}
+use_google_auth=${use_google_auth}
 
 
 --===============BOUNDARY==
@@ -79,6 +80,12 @@ echo "--> SET MEMBEROF REQUIREMENT"
 # SET LDAP USE SSL
 echo "--> SET LDAP TO USE SSL"
 /usr/local/openvpn_as/scripts/sacli --key "auth.ldap.0.use_ssl" --value "${ldap_use_ssl}" ConfigPut
+
+if [ ${use_google_auth} == 1 ]; then
+  echo "--> USE GOOGLE AUTHENTICATOR"
+  # USE GOOGLE AUTHENTICATOR
+  /usr/local/openvpn_as/scripts/sacli --key "vpn.server.google_auth.enable" --value "true" ConfigPut
+fi
 
 echo "--> RESTART OPENVPN ACCESS SERVER TO SAVE AND APPLY CHANGES"
 

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,13 @@ variable openvpn_ldap_use_ssl {
   default = "always"
 
 }
+
+###############################################################################
+### GOOGLE AUTHENTICATOR CONFIGURATION
+###############################################################################
+variable use_google_auth {
+  default = "0"
+  type = "string"
+  description = "Use Google Authenticator for 2FA"
+}
+


### PR DESCRIPTION
This PR adds optional use of Google Authenticator for 2 factor auth. Default setting is set to no 2FA, so not to break existing deployments.