### PR TITLE
Add ability to use preallocated fixed Elastic IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Access Server script ./sacli
         openvpn_ldap_add_req            = "memberOf=cn=openvpn,ou=Users,o=<account_id>,dc=jumpcloud,dc=com"
         openvpn_ldap_use_ssl            = "always"
         custom_security_groups          = ["<security group ID", "security group ID"]
+        public_ip                       = "<ip_address>" or ""
     }
 
 ### providers.tf

--- a/aws_eip.openvpn.tf
+++ b/aws_eip.openvpn.tf
@@ -1,0 +1,21 @@
+data "aws_eip" "openvpn" {
+  public_ip = "${var.public_ip}"
+  count = "${var.public_ip != "" ? 1 : 0 }"
+}
+ # CREATE ELASTIC IP ADDRESS
+resource "aws_eip" "openvpn" {
+  count = "${var.public_ip != "" ? 0 : 1 }"
+   instance          = "${aws_instance.openvpn.id}"
+  network_interface = "${aws_instance.openvpn.network_interface_id}"
+  vpc               = true
+}
+ locals {
+  public_ip     = "${var.public_ip != "" ? join("", data.aws_eip.openvpn.*.public_ip) : join("", aws_eip.openvpn.*.public_ip) }"
+  allocation_id = "${var.public_ip != "" ? join("", data.aws_eip.openvpn.*.id)        : join("", aws_eip.openvpn.*.id) }"
+}
+ # ASSIGN ELASTIC IP ADDRESS
+resource "aws_eip_association" "openvpn" {
+  instance_id   = "${aws_instance.openvpn.id}"
+  allocation_id = "${local.allocation_id}"
+}
+

--- a/aws_instance.openvpn.tf
+++ b/aws_instance.openvpn.tf
@@ -23,19 +23,6 @@ resource "aws_instance" "openvpn" {
   }
 }
 
-# CREATE ELASTIC IP ADDRESS
-resource "aws_eip" "openvpn" {
-  instance          = "${aws_instance.openvpn.id}"
-  network_interface = "${aws_instance.openvpn.network_interface_id}"
-  vpc               = true
-}
-
-# ASSIGN ELASTIC IP ADDRESS
-resource "aws_eip_association" "openvpn" {
-  instance_id   = "${aws_instance.openvpn.id}"
-  allocation_id = "${aws_eip.openvpn.id}"
-}
-
 # USER DATA TEMPLATE TO PRE-CONFIGURE THE OPENVPN ACCESS SERVER
 data "template_file" "user_data" {
   template = "${file("${path.module}/user_data.tpl")}"

--- a/aws_route53_record.public.tf
+++ b/aws_route53_record.public.tf
@@ -4,5 +4,5 @@ resource "aws_route53_record" "public" {
   name    = "${var.openvpn_public_dns}"
   type    = "A"
   ttl     = "300"
-  records = ["${aws_eip.openvpn.public_ip}"]
+  records = ["${local.public_ip}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,5 +19,5 @@ output "private_ip" {
 }
 
 output "public_ip" {
-  value = "${aws_eip.openvpn.public_ip}"
+  value = "${local.public_ip}"
 }

--- a/readme.tf
+++ b/readme.tf
@@ -20,7 +20,7 @@ This stack provisions an OpenVPN Access Server in the ${upper(terraform.workspac
 |Private DNS|${aws_instance.openvpn.private_dns}|
 |Private IP|${aws_instance.openvpn.private_ip}|
 |Public DNS|${var.openvpn_public_dns}|
-|Public IP|${aws_eip.openvpn.public_ip}|
+|Public IP|${local.public_ip}|
 
 
 ### USER DATA

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,12 @@ variable openvpn_ldap_use_ssl {
   default = "always"
 
 }
+
+###############################################################################
+### USE PREALLOCATED FIXED ELASTIC IP
+###############################################################################
+variable public_ip {
+  default = ""
+  type = "string"
+  description = "To use preallocated static IP address, please set variable to existing EIP. If it's empty, it will be created dynamically."
+}


### PR DESCRIPTION
There are situations when VPN setup needs to use permanent Elastic IP that would not change during `destroy`/`apply` cycle. In this scenario EIP needs to be pre-created before provisioning OpenVPN server, thus EIP won't be released by running `terraform destroy`.

This PR allows defining use of pre-created EIP. If IP address is not defined in calling module (i.e. `public_ip == ""`) then as before new EIP will be provisioned by the module and will be released on `terraform destroy`. Default is set to `public_ip = ""`, so should not break existing installations.