### PR TITLE
Add fix for slow admin web UI

### DIFF
--- a/user_data.tpl
+++ b/user_data.tpl
@@ -80,6 +80,12 @@ echo "--> SET MEMBEROF REQUIREMENT"
 echo "--> SET LDAP TO USE SSL"
 /usr/local/openvpn_as/scripts/sacli --key "auth.ldap.0.use_ssl" --value "${ldap_use_ssl}" ConfigPut
 
+echo "APPLY FIX FOR WEB UI SLOWNESS"
+/usr/local/openvpn_as/scripts/sacli --key vpn.client.client_sockbuf --value 0 ConfigPut
+/usr/local/openvpn_as/scripts/sacli --key vpn.server.server_sockbuf_tcp --value 0 ConfigPut
+/usr/local/openvpn_as/scripts/sacli --key vpn.server.server_sockbuf_udp --value 0 ConfigPut
+
+
 echo "--> RESTART OPENVPN ACCESS SERVER TO SAVE AND APPLY CHANGES"
 
 # RESTART OPENVPN ACCESS SERVER TO SAVE AND APPLY CONFIGURATION CHANGES


### PR DESCRIPTION
Combination of some Linux kernels with MacOSX clients can lead to very
slow to respond admin web UI. Slowness can be fixed by changing
configuration on server side.

Quote: "It turns out that in modern kernels on Ubuntu 16, possibly other
OSes as well, in combination with macOS devices, using port-sharing in
OpenVPN, with the default settings that Access Server uses for buffer
settings, on Amazon AWS, causes a rather weird TCP window scaling
problem which slows things down considerably. We have already
implemented a fix in the next release of access server. "

https://forums.openvpn.net/viewtopic.php?t=26203